### PR TITLE
generic-action-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StealthTracker
 
-StealthTracker v3.3 by Justin Freitas
+StealthTracker v3.4 by Justin Freitas
 
 ReadMe and Usage Notes
 
@@ -43,6 +43,7 @@ Changelist:
 - v3.2.1 - Fix and protection against null pointer exception reported by UnlivingLuke.
 - v3.2.2 - Fix to account for all dice in the stealth skill roll when computing total for effect.
 - v3.2.3 - Improve dice check in skill handler by using common code.
-- v3.3 - Use looked up, translated strings for 'Stealth' and 'Dexterity' so that the StealthTracker functionality will work for localized rulesets.
+- v3.3 - Use looked up, translated strings for 'Stealth' and 'Dexterity' so that the StealthTracker functionality will work for localized rulesets.  Thanks to shoebill for the suggestion.
+- v3.4 - Added support for the Generic Action extension Hide action to be processed like Stealth rolls are.  Thanks to BushViper and plap3014 for the suggestion and SilentRuin for support.
 
 ![alt text](https://github.com/JustinFreitas/StealthTracker/blob/master/graphics/StealthTrackerScreenshot.jpg?raw=true)

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <root version="3.3">
-	<announcement text="StealthTracker v3.3 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-21 Justin Freitas (12/28/21)" font="emotefont" icon="stealth_icon" />
+	<announcement text="StealthTracker v3.4 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-21 Justin Freitas (12/31/21)" font="emotefont" icon="stealth_icon" />
 	<properties>
 		<name>Feature: StealthTracker</name>
-		<version>3.3</version>
+		<version>3.4</version>
 		<loadorder>999</loadorder>
 		<author>Justin Freitas</author>
 		<description>For the current Combat Tracker actor, chat messages will display for each other CT actor whose tracked stealth roll is greater than the current actor's Passive Perception.  Stealth roll values are tracked in the CT actor node via an effect.  This effect will be automatically added/updated on a Stealth roll (always for GM and only when it's a player's turn for them).</description>

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -59,6 +59,11 @@ function onInit()
 	ActionPower.onCastSaveStealthTracker = ActionPower.onCastSave
 	ActionPower.onCastSave = onRollCastSave
 	ActionsManager.registerResultHandler("castsave", onRollCastSave)
+
+	-- Compatibility with Generic Actions extension so that Hide action is treated as Stealth skill check.
+	if ActionGeneral then
+		ActionsManager.registerPostRollHandler("genactroll", onGenericActionPostRoll)
+	end
 end
 
 -- Alphebetical list of functions below (onInit() above was an exception)
@@ -574,6 +579,13 @@ function onDropEvent(rSource, rTarget, draginfo)
 
 	-- This is required, otherwise, the wired drop handler fires twice.  It terminates the default drop processing.
 	return true
+end
+
+-- Check for StealthTracker processing on a GenericAction (extension) Hide roll.
+function onGenericActionPostRoll(rSource, rRoll)
+	if rRoll and ActionsManager.doesRollHaveDice(rRoll) and rRoll.sType == "genactroll" and rRoll.sGenericAction == "Hide" then
+		processStealth(rSource, rRoll)
+	end
 end
 
 -- Attack roll handler


### PR DESCRIPTION
Added support for the Generic Action extension Hide action to be processed like Stealth rolls are.  Thanks to BushViper and plap3014 for the suggestion and SilentRuin for support.