### PR TITLE
assign-npc-stealth-skill-on-turn-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StealthTracker
 
-StealthTracker v3.4.1 by Justin Freitas
+StealthTracker v3.4.2 by Justin Freitas
 
 ReadMe and Usage Notes
 
@@ -47,5 +47,6 @@ Changelist:
 - v3.3 - Use looked up, translated strings for 'Stealth' and 'Dexterity' so that the StealthTracker functionality will work for localized rulesets.  Thanks to shoebill for the suggestion.
 - v3.4 - Added support for the Generic Action extension Hide action to be processed like Stealth rolls are.  Thanks to BushViper and plap3014 for the suggestion and SilentRuin for support.
 - v3.4.1 - Decode adv/disadv in the post roll handler for the Generic Actions extension compatibility before using the roll total to assign a Stealth effect.  Special thanks to Ludd_G for the bug report.
+- v3.4.2 - Account for a change in FG CT onAdd handler behavior and don't assign the NPC sheet Stealth skill at that time due to uninitialized attributes.  Do it onTurnStart instead where the attributes are correct until the issue with FG is resolved.  Thanks again to Ludd_G for the report.
 
 ![alt text](https://github.com/JustinFreitas/StealthTracker/blob/master/graphics/StealthTrackerScreenshot.jpg?raw=true)

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <root version="3.3">
-	<announcement text="StealthTracker v3.4.1 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-22 Justin Freitas (1/5/22)" font="emotefont" icon="stealth_icon" />
+	<announcement text="StealthTracker v3.4.2 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-22 Justin Freitas (1/7/22)" font="emotefont" icon="stealth_icon" />
 	<properties>
 		<name>Feature: StealthTracker</name>
-		<version>3.4.1</version>
+		<version>3.4.2</version>
 		<loadorder>999</loadorder>
 		<author>Justin Freitas</author>
 		<description>For the current Combat Tracker actor, chat messages will display for each other CT actor whose tracked stealth roll is greater than the current actor's Passive Perception.  Stealth roll values are tracked in the CT actor node via an effect.  This effect will be automatically added/updated on a Stealth roll (always for GM and only when it's a player's turn for them).</description>

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -42,9 +42,6 @@ function onInit()
 		Comm.registerSlashHandler("stealth", processChatCommand)
 		-- TODO: This will be the new way of doing things once they deprecate Comm.registerSlashHandler() which is coming soon.
 		--ChatManager.registerSlashCommand("stealth", processChatCommand)
-
-		-- Register a handler for CT node creation for a place to check to see if Stealth exists on any npc sheet (instead of just on next turn like it is now).
-		DB.addHandler("combattracker.list.*", "onAdd", onCTAdd)
 	end
 
 	-- Unlike the Custom Turn and Init events above, the dice result handler must be registered on host and client.
@@ -555,11 +552,6 @@ end
 function onCombatResetEvent()
 	-- We are exiting initiative/combat, so clear all StealthTracker data from CT actors.
 	clearAllStealthTrackerDataFromCT()
-end
-
--- Handler for when an actor is added to the Combat Tracker.  Registered in onInit().
-function onCTAdd(nodeAdded)
-	ensureStealthSkillExistsOnNpc(nodeAdded)
 end
 
 -- Fires when something is dropped on the CT


### PR DESCRIPTION
- v3.4.2 - Account for a change in FG CT onAdd handler behavior and don't assign the NPC sheet Stealth skill at that time due to uninitialized attributes.  Do it onTurnStart instead where the attributes are correct until the issue with FG is resolved.  Thanks again to Ludd_G for the report.
