### PR TITLE
Verbosity off option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StealthTracker
 
-StealthTracker v3.5 by Justin Freitas
+StealthTracker v3.6 by Justin Freitas
 
 ReadMe and Usage Notes
 
@@ -52,5 +52,6 @@ Changelist:
 - v3.4.4 - Fix for camel cased typo in gmatch function call.  Thanks to carrierpl for the report.
 - v3.4.5 - gmatch was a mistake entirely, revert to gsub
 - v3.5 - Bug fix for incorrect stat reporting in attack from stealth scenario.  Don't process stealth on debilitated actors or actors of the same faction as the one being analyzed (unless Faction Filter option is set to off).  Massive reduction in chat verbosity. New option for verbose output that's mostly for clarifying information when no output is actually necessary (defaults to off). Thanks to Ludd_G for the suggestions and inspiration.  Wiring of castsave through the messaging mechanism and refactor attack and castsave to reduce duplication.  Only one StealthTracker chat entry per roll or turn or command, this required some rework on how things are displayed in chat.  Everything is done host side now except for tower checks.  New option to allow for out of turn or out of combat stealth tracking and functionality (defaults to off/none).
+- v3.6 - Changed the existing Verbosity option to allow for disabling StealthTracker chat output.  Just set it to 'off'.  Standard is the default and has normal StealthTracker output.  Max has all Standard output, plus some additional.  Thanks to MrDDT for the suggestion.
 
 ![alt text](https://github.com/JustinFreitas/StealthTracker/blob/master/graphics/StealthTrackerScreenshot.jpg?raw=true)

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <root version="3.3">
-	<announcement text="StealthTracker v3.5 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-22 Justin Freitas (1/17/22)" font="emotefont" icon="stealth_icon" />
+	<announcement text="StealthTracker v3.6 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-22 Justin Freitas (1/19/22)" font="emotefont" icon="stealth_icon" />
 	<properties>
 		<name>Feature: StealthTracker</name>
-		<version>3.5</version>
+		<version>3.6</version>
 		<loadorder>999</loadorder>
 		<author>Justin Freitas</author>
 		<description>Stealth tracking via effect with related information regarding hidden and unaware actors.</description>
@@ -14,19 +14,19 @@
 	</properties>
 	
 	<base>
-		<string name="option_header_stealthtracker">StealthTracker (GM)</string>
+		<string name="option_header_STEALTHTRACKER">StealthTracker (GM)</string>
 		<string name="option_label_STEALTHTRACKER_ALLOW_OUT_OF">Player: Out of turn or combat stealth</string>
 		<string name="option_label_STEALTHTRACKER_EXPIRE_EFFECT">CT: Expire stealth effect</string>
 		<string name="option_label_STEALTHTRACKER_FACTION_FILTER">CT: Ignore stealth same faction</string>
 		<string name="option_label_STEALTHTRACKER_VISIBILITY">Player: Show Stealth info</string>
-		<string name="option_label_STEALTHTRACKER_VERBOSE">Chat: Verbose mode</string>
-		<string name="option_val_action">Action</string>
-		<string name="option_val_action_and_round">Action and Round</string>
-		<string name="option_val_chat_and_effects">Chat and Effects</string>
-		<string name="option_val_effects">Effects</string>
-		<string name="option_val_none">None</string>
-		<string name="option_val_turn">Turn</string>		
-		<string name="option_val_turn_and_combat">Turn and Combat</string>
+		<string name="option_label_STEALTHTRACKER_VERBOSE">Chat: Verbosity</string>
+		<string name="option_val_action_STEALTHTRACKER">Action</string>
+		<string name="option_val_action_and_round_STEALTHTRACKER">Action and Round</string>
+		<string name="option_val_chat_and_effects_STEALTHTRACKER">Chat and Effects</string>
+		<string name="option_val_effects_STEALTHTRACKER">Effects</string>
+		<string name="option_val_none_STEALTHTRACKER">None</string>
+		<string name="option_val_turn_STEALTHTRACKER">Turn</string>		
+		<string name="option_val_turn_and_combat_STEALTHTRACKER">Turn and Combat</string>
 
 		<script name="StealthTracker" file="scripts/stealthtracker.lua" />
 		<icon name="stealth_icon" file="graphics/icons/stealth_icon.png" />

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -485,9 +485,7 @@ function getFormattedAndClearAllStealthTrackerDataFromCTIfAllowed(aOutput)
 		deleteAllStealthEffects(nodeCT)
 	end
 
-	if not bForce and checkVerbosityMax() then
-		insertFormattedTextWithSeparatorIfNonEmpty(aOutput, "All Stealth effects deleted on combat reset.")
-	end
+	insertFormattedTextWithSeparatorIfNonEmpty(aOutput, "All Stealth effects deleted on combat reset.")
 end
 
 function getFormattedHiddenAndUnawareTargetsWithTotal(nodeActorCT, aOutput)

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -284,6 +284,8 @@ function displayTableIfNonEmpty(aTable, bForce)
 end
 
 function displayTowerRoll(bAttackFromStealth)
+	if checkVerbosityOff() then return end
+
 	local sAnAction = ternary(bAttackFromStealth, "An attack", "A cast save")
 	local sActions = ternary(bAttackFromStealth, "Attacks", "Cast saves")
 	displayChatMessage(string.format("%s was rolled in the tower.  %s should be rolled in the open for proper StealthTracker processing.", sAnAction, sActions), USER_ISHOST)
@@ -808,7 +810,7 @@ function onRollAction(rSource, rTarget, rRoll)
 	local bAttackFromStealth = rRoll.sType == "attack"
 
 	-- When attacks are rolled in the tower, the target is always nil.
-	if not rTarget and rRoll.bSecret and not checkVerbosityOff() then
+	if not rTarget and rRoll.bSecret then
 		displayTowerRoll(bAttackFromStealth)
 	end
 

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -20,6 +20,7 @@ LOCALIZED_STEALTH_ABV = "S"
 LOCALIZED_STEALTH_LOWER = LOCALIZED_STEALTH:lower()
 OOB_MSGTYPE_UPDATESTEALTH = "updatestealth"
 OOB_MSGTYPE_ACTIONFROMSTEALTH = "actionfromstealth"
+SECRET = true
 ST_STEALTH_DISABLED_OUT_OF_FORMAT = "Stealth processing disabled when out of %s."
 USER_ISHOST = false
 
@@ -97,7 +98,7 @@ function checkAndDisplayAllowOutOfCombatAndTurnChecks(vActor)
 	local nodeCT = ActorManager.getCTNode(vActor)
 	if CombatManager.getActiveCT() ~= nodeCT and not checkAllowOutOfTurn() then
 		if checkVerbosityMax() then
-			displayChatMessage(string.format(ST_STEALTH_DISABLED_OUT_OF_FORMAT, "turn"), true)
+			displayChatMessage(string.format(ST_STEALTH_DISABLED_OUT_OF_FORMAT, "turn"), SECRET)
 		end
 
 		return false
@@ -109,7 +110,7 @@ end
 function checkAndDisplayCTInactiveAndOutsideOfCombatStealthDisallowed()
 	if not CombatManager.getActiveCT() and not checkAllowOutOfCombat() then
 		if checkVerbosityMax() then
-			displayChatMessage(string.format(ST_STEALTH_DISABLED_OUT_OF_FORMAT, "combat"), true)
+			displayChatMessage(string.format(ST_STEALTH_DISABLED_OUT_OF_FORMAT, "combat"), SECRET)
 		end
 
 		return true
@@ -168,7 +169,7 @@ function displayDebilitatingConditionChatMessage(vActor, sCondition, bForce)
 	local sText = string.format("'%s' is %s, skipping StealthTracker processing.",
 								ActorManager.getDisplayName(vActor),
 								sCondition)
-	displayChatMessage(sText, true)
+	displayChatMessage(sText, SECRET)
 end
 
 -- Logic to process an attack from stealth (for checking if enemies could have been attacked with advantage, etc).  It's call from BOTH an attack roll and a spell attack roll (i.e. cast and castattack).
@@ -265,7 +266,7 @@ function displayStealthCheckInformationWithConditionAndVerboseChecks(nodeCT, bFo
 	local nCount = getFormattedHiddenAndUnawareTargetsWithTotal(nodeCT, aOutput)
 	if nCount == 0 and (bForce or checkVerbosityMax()) then
 		local sText = string.format("No hidden or unaware actors to '%s'.", ActorManager.getDisplayName(nodeCT))
-		displayChatMessage(sText, true)
+		displayChatMessage(sText, SECRET)
 		return
 	end
 
@@ -278,7 +279,7 @@ function displayTableIfNonEmpty(aTable, bForce)
 	aTable = validateTableOrNew(aTable)
 	if #aTable > 0 then
 		local sDisplay = table.concat(aTable, "\r")
-		displayChatMessage(sDisplay, true)
+		displayChatMessage(sDisplay, SECRET)
 	end
 end
 
@@ -857,7 +858,7 @@ function processChatCommand(_, sParams)
 	-- Only allow administrative subcommands when run on the host/DM system.
 	local sFailedSubcommand = processHostOnlySubcommands(sParams)
 	if sFailedSubcommand then
-		displayChatMessage("Unrecognized subcommand: " .. sFailedSubcommand, true)
+		displayChatMessage("Unrecognized subcommand: " .. sFailedSubcommand, SECRET)
 	end
 end
 
@@ -869,7 +870,7 @@ function processHostOnlySubcommands(sSubcommand)
 		-- Get the node for the current CT actor.
 		local nodeActiveCT = CombatManager.getActiveCT()
 		if not nodeActiveCT then
-			displayChatMessage("No active Combat Tracker actor.", true)
+			displayChatMessage("No active Combat Tracker actor.", SECRET)
 		else
 			displayStealthCheckInformationWithConditionAndVerboseChecks(nodeActiveCT, FORCE_DISPLAY)
 		end


### PR DESCRIPTION
Changed the existing Verbosity option to allow for disabling StealthTracker chat output.  Just set it to 'off'.  Standard is the default and has normal StealthTracker output.  Max has all Standard output, plus some additional.  Thanks to MrDDT for the suggestion.