### PR TITLE
Deprecation Fixes and Removal of Stealth Expiration for Cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StealthTracker
 
-StealthTracker v3.6 by Justin Freitas
+StealthTracker v3.6.1 by Justin Freitas
 
 ReadMe and Usage Notes
 
@@ -53,5 +53,6 @@ Changelist:
 - v3.4.5 - gmatch was a mistake entirely, revert to gsub
 - v3.5 - Bug fix for incorrect stat reporting in attack from stealth scenario.  Don't process stealth on debilitated actors or actors of the same faction as the one being analyzed (unless Faction Filter option is set to off).  Massive reduction in chat verbosity. New option for verbose output that's mostly for clarifying information when no output is actually necessary (defaults to off). Thanks to Ludd_G for the suggestions and inspiration.  Wiring of castsave through the messaging mechanism and refactor attack and castsave to reduce duplication.  Only one StealthTracker chat entry per roll or turn or command, this required some rework on how things are displayed in chat.  Everything is done host side now except for tower checks.  New option to allow for out of turn or out of combat stealth tracking and functionality (defaults to off/none).
 - v3.6 - Changed the existing Verbosity option to allow for disabling StealthTracker chat output.  Just set it to 'off'.  Standard is the default and has normal StealthTracker output.  Max has all Standard output, plus some additional.  Thanks to MrDDT for the suggestion.
+- v3.6.1 - I ripped out the expiration of stealth on cast.  Spell casts that have attack rolls will still work as those are attacks already.  Any spell that is a save could be argued either way so I'll leave expiration in those cases up to the DM. 
 
 ![alt text](https://github.com/JustinFreitas/StealthTracker/blob/master/graphics/StealthTrackerScreenshot.jpg?raw=true)

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <root version="3.3">
-	<announcement text="StealthTracker v3.6 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-22 Justin Freitas (1/19/22)" font="emotefont" icon="stealth_icon" />
+	<announcement text="StealthTracker v3.6.1 for FGC/FGU v3.3.15+, 5E\rCopyright 2016-22 Justin Freitas (1/24/22)" font="emotefont" icon="stealth_icon" />
 	<properties>
 		<name>Feature: StealthTracker</name>
-		<version>3.6</version>
+		<version>3.6.1</version>
 		<loadorder>999</loadorder>
 		<author>Justin Freitas</author>
 		<description>Stealth tracking via effect with related information regarding hidden and unaware actors.</description>
@@ -20,8 +20,8 @@
 		<string name="option_label_STEALTHTRACKER_FACTION_FILTER">CT: Ignore stealth same faction</string>
 		<string name="option_label_STEALTHTRACKER_VISIBILITY">Player: Show Stealth info</string>
 		<string name="option_label_STEALTHTRACKER_VERBOSE">Chat: Verbosity</string>
-		<string name="option_val_action_STEALTHTRACKER">Action</string>
-		<string name="option_val_action_and_round_STEALTHTRACKER">Action and Round</string>
+		<string name="option_val_attack_STEALTHTRACKER">Attack</string>
+		<string name="option_val_attack_and_round_STEALTHTRACKER">Attack and Round</string>
 		<string name="option_val_chat_and_effects_STEALTHTRACKER">Chat and Effects</string>
 		<string name="option_val_effects_STEALTHTRACKER">Effects</string>
 		<string name="option_val_none_STEALTHTRACKER">None</string>

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -22,6 +22,11 @@ OOB_MSGTYPE_UPDATESTEALTH = "updatestealth"
 OOB_MSGTYPE_ACTIONFROMSTEALTH = "actionfromstealth"
 SECRET = true
 ST_STEALTH_DISABLED_OUT_OF_FORMAT = "Stealth processing disabled when out of %s."
+STEALTHTRACKER_ALLOW_OUT_OF = "STEALTHTRACKER_ALLOW_OUT_OF"
+STEALTHTRACKER_EXPIRE_EFFECT = "STEALTHTRACKER_EXPIRE_EFFECT"
+STEALTHTRACKER_FACTION_FILTER = "STEALTHTRACKER_FACTION_FILTER"
+STEALTHTRACKER_VERBOSE = "STEALTHTRACKER_VERBOSE"
+STEALTHTRACKER_VISIBILITY = "STEALTHTRACKER_VISIBILITY"
 USER_ISHOST = false
 
 -- This function is required for all extensions to initialize variables and spit out the copyright and name of the extension as it loads
@@ -33,16 +38,16 @@ function onInit()
 	LOCALIZED_STEALTH_LOWER = LOCALIZED_STEALTH:lower()
 	USER_ISHOST = User.isHost()
 
-	OptionsManager.registerOption2("STEALTHTRACKER_ALLOW_OUT_OF", false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_ALLOW_OUT_OF", "option_entry_cycler",
+	OptionsManager.registerOption2(STEALTHTRACKER_ALLOW_OUT_OF, false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_ALLOW_OUT_OF", "option_entry_cycler",
 		{ baselabel = "option_val_none_STEALTHTRACKER", baseval = "none", labels = "option_val_turn_STEALTHTRACKER|option_val_turn_and_combat_STEALTHTRACKER", values = "turn|all", default = "none" })
-	OptionsManager.registerOption2("STEALTHTRACKER_EXPIRE_EFFECT", false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_EXPIRE_EFFECT", "option_entry_cycler",
+	OptionsManager.registerOption2(STEALTHTRACKER_EXPIRE_EFFECT, false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_EXPIRE_EFFECT", "option_entry_cycler",
 		{ baselabel = "option_val_action_and_round_STEALTHTRACKER", baseval = "all", labels = "option_val_action_STEALTHTRACKER|option_val_none_STEALTHTRACKER", values = "action|none", default = "all" })
-	OptionsManager.registerOption2("STEALTHTRACKER_FACTION_FILTER", false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_FACTION_FILTER", "option_entry_cycler",
+	OptionsManager.registerOption2(STEALTHTRACKER_FACTION_FILTER, false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_FACTION_FILTER", "option_entry_cycler",
 		{ labels = "option_val_off", values = "off", baselabel = "option_val_on", baseval = "on", default = "on" })
 	-- TODO: Chat visibility?  Should we allow it for anything or remove the option?  Right now it does nothing, only none and effect have meaning.  With one chat per action would require two lists.
-	OptionsManager.registerOption2("STEALTHTRACKER_VISIBILITY", false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_VISIBILITY", "option_entry_cycler",
+	OptionsManager.registerOption2(STEALTHTRACKER_VISIBILITY, false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_VISIBILITY", "option_entry_cycler",
 		{ baselabel = "option_val_chat_and_effects_STEALTHTRACKER", baseval = "all", labels = "option_val_effects_STEALTHTRACKER|option_val_none_STEALTHTRACKER", values = "effects|none", default = "effects" })
-	OptionsManager.registerOption2("STEALTHTRACKER_VERBOSE", false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_VERBOSE", "option_entry_cycler",
+	OptionsManager.registerOption2(STEALTHTRACKER_VERBOSE, false, "option_header_STEALTHTRACKER", "option_label_STEALTHTRACKER_VERBOSE", "option_entry_cycler",
 		{ baselabel = "option_val_standard", baseval = "standard", labels = "option_val_max|option_val_off", values = "max|off", default = "standard" })
 
 	-- Only set up the Custom Turn, Combat Reset, Custom Drop, and OOB Message event handlers on the host machine because it has access/permission to all of the necessary data.
@@ -83,11 +88,11 @@ function booleanToNumber(bValue)
 end
 
 function checkAllowOutOfCombat()
-	return OptionsManager.getOption("STEALTHTRACKER_ALLOW_OUT_OF") == "all"
+	return OptionsManager.getOption(STEALTHTRACKER_ALLOW_OUT_OF) == "all"
 end
 
 function checkAllowOutOfTurn()
-	return OptionsManager.getOption("STEALTHTRACKER_ALLOW_OUT_OF") == "turn" or
+	return OptionsManager.getOption(STEALTHTRACKER_ALLOW_OUT_OF) == "turn" or
 		   checkAllowOutOfCombat()
 end
 
@@ -120,23 +125,23 @@ function checkAndDisplayCTInactiveAndOutsideOfCombatStealthDisallowed()
 end
 
 function checkExpireActionAndRound()
-	return OptionsManager.getOption("STEALTHTRACKER_EXPIRE_EFFECT") == "all"
+	return OptionsManager.getOption(STEALTHTRACKER_EXPIRE_EFFECT) == "all"
 end
 
 function checkExpireNone()
-	return OptionsManager.getOption("STEALTHTRACKER_EXPIRE_EFFECT") == "none"
+	return OptionsManager.getOption(STEALTHTRACKER_EXPIRE_EFFECT) == "none"
 end
 
 function checkFactionFilter()
-	return OptionsManager.getOption("STEALTHTRACKER_FACTION_FILTER") == "on"
+	return OptionsManager.getOption(STEALTHTRACKER_FACTION_FILTER) == "on"
 end
 
 function checkVerbosityMax()
-	return OptionsManager.getOption("STEALTHTRACKER_VERBOSE") == "max"
+	return OptionsManager.getOption(STEALTHTRACKER_VERBOSE) == "max"
 end
 
 function checkVerbosityOff()
-	return OptionsManager.getOption("STEALTHTRACKER_VERBOSE") == "off"
+	return OptionsManager.getOption(STEALTHTRACKER_VERBOSE) == "off"
 end
 
 -- Deletes all of the stealth effects for a CT node (no expiration warning because this is cleanup and not effect usage causing the deletion).
@@ -698,7 +703,7 @@ function isNpc(vActor)
 end
 
 function isPlayerStealthInfoDisabled()
-	return OptionsManager.getOption("STEALTHTRACKER_VISIBILITY") == "none"
+	return OptionsManager.getOption(STEALTHTRACKER_VISIBILITY) == "none"
 end
 
 -- Checks to see if the roll description (or drag info data) is a stealth skill roll.

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -665,8 +665,8 @@ function handleUpdateStealth(msgOOB)
 end
 
 -- Check a CT node for a valid type.  Currently any non-empty type is valid but might be restricted in the future (i.e. Trap, Object, etc.)
-function hasValidType(nodeCT)
-	return nodeCT and ActorManager.getType(nodeCT) ~= ""
+function hasValidType(vActor)
+	return ActorManager.getRecordType(vActor) ~= ""
 end
 
 function insertBlankSeparatorIfNotEmpty(aTable)
@@ -694,7 +694,7 @@ function isFriend(vActor)
 end
 
 function isNpc(vActor)
-	return vActor and ActorManager.getType(vActor) == "npc"
+	return ActorManager.getRecordType(vActor) == "npc"
 end
 
 function isPlayerStealthInfoDisabled()
@@ -912,12 +912,9 @@ function setNodeWithStealthValue(sCTNode, nStealthTotal)
 		nEffectDuration = 2  -- because the effect init we used is after the user's turn.
 	end
 
-	local rActor = ActorManager.resolveActor(nodeCT)
-	if not rActor then return end
-
 	-- Check and see if the 'share none' option is enabled.  In that case or non-friendly npcs, we'll want the effect to be GM only.
 	local nEffectGMOnly = booleanToNumber(isPlayerStealthInfoDisabled()
-										  or (isNpc(rActor) and not isFriend(rActor)))
+										  or (isNpc(nodeCT) and not isFriend(nodeCT)))
 	local rEffect = {
 		sName = sEffectName,
 		nInit = nEffectExpirationInit,


### PR DESCRIPTION
- v3.6.1 - I ripped out the expiration of stealth on cast.  Spell casts that have attack rolls will still work as those are attacks already.  Any spell that is a save could be argued either way so I'll leave expiration in those cases up to the DM. 
