### PR TITLE
V3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 https://github.com/JustinFreitas/StealthTracker
 
 
-StealthTracker v3.12 by Justin Freitas
+StealthTracker v3.13 by Justin Freitas
 
 ReadMe and Usage Notes
 
@@ -66,5 +66,6 @@ Changelist:
 - v3.10 - Changed the in-combat firing of the stealth functionality fromn onTurnStart to requestActivation.  Now, it works when you click the left CT bar to activate an actor that way (and still works when using the Next Actor button too).  I'll be applying this change to all of my Tracker extensions.  Updated the option names to be more understandable and have correct casing.  Updated the unidentified creature name usage to be correct if an NPC is unidentified.  It will now use the unidentified name in that case so chat matches CT name, reducing confusion.
 - v3.11 - Add Passive Perception greater than zero to the valid actor check.  Fixed a bug with the proficiency bonus of NPCs being incorrect in fractional cases and probably other cases also.
 - v3.12 - Update the status text for clarity.  Icon update using Sir Motte's template.
+- v3.13 - No secret eye icon in chat messages, it takes too much space.  Change to the build script.  Later loading sequence to ensure new icon.
 
 ![alt text](https://github.com/JustinFreitas/StealthTracker/blob/master/graphics/StealthTrackerScreenshot.png?raw=true)

--- a/build/zip-items.cmd
+++ b/build/zip-items.cmd
@@ -26,7 +26,7 @@ echo end if >> _zipIt.vbs
 @ECHO Zipping, please wait...
 mkdir %TEMPDIR%
 xcopy /y /s %FILETOZIP% %TEMPDIR%
-WScript _zipIt.vbs  %TEMPDIR%  %OUTPUTZIP%
+cscript //NoLogo _zipIt.vbs  %TEMPDIR%  %OUTPUTZIP%
 del _zipIt.vbs
 rmdir /s /q  %TEMPDIR%
 

--- a/extension.xml
+++ b/extension.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <root version="3.3" release="8.1|CoreRPG:4.1">
-	<announcement text="StealthTracker v3.12 FGC/FGU 5E, 7/2/23\r2016-2023 Justin Freitas" font="emotefont" icon="stealth_icon" />
+	<announcement text="StealthTracker v3.13 FGC/FGU 5E, 7/3/23\r2016-2023 Justin Freitas" font="emotefont" icon="stealth_icon" />
 	<properties>
 		<name>Feature: StealthTracker</name>
-		<version>3.12</version>
+		<version>3.13</version>
 		<loadorder>9999</loadorder>
 		<author>Justin Freitas</author>
 		<description>Stealth tracking via effects in the Combat Tracker with related information regarding the hiding actor and who can and cannot see them.</description>

--- a/scripts/stealthtracker.lua
+++ b/scripts/stealthtracker.lua
@@ -192,7 +192,7 @@ end
 function displayChatMessage(sFormattedText, bSecret)
 	if sFormattedText == nil then return end
 
-	local msg = {font = "msgfont", icon = "stealth_icon", secret = bSecret, text = sFormattedText}
+	local msg = {font = "msgfont", icon = "stealth_icon", secret = false, text = sFormattedText}  -- secret true shows the cross eye icon, wasting space
 	-- deliverChatMessage() is a broadcast mechanism, addChatMessage() is local only.
 	if bSecret then
 		Comm.addChatMessage(msg)


### PR DESCRIPTION
No secret eye icon in chat messages, it takes too much space.  Change to the build script.  Later loading sequence to ensure new icon.